### PR TITLE
Update index.js

### DIFF
--- a/lib/swagger-express/index.js
+++ b/lib/swagger-express/index.js
@@ -46,6 +46,11 @@ function parseJsDocs(file, fn) {
     var fragments = js.match(regex);
     var docs = [];
 
+    if (!fragments) {
+      fn(null, docs);
+      return;
+    }
+    
     for (var i = 0; i < fragments.length; i++) {
       var fragment = fragments[i];
       var doc = doctrine.parse(fragment, { unwrap: true });


### PR DESCRIPTION
Fixes the case when you pass a bunch of controller files but only some of them contain jsdoc annotations.
eg: 

```
app.use(swagger.init(app, {
    apiVersion: '1.0',
    ...,
    apis: fs.readdirSync('./controllers').map(function (filename) {
        return path.join(controllersPath, filename);
    }),
    ...
}));
```
