### PR TITLE
Simplify Swagger serving

### DIFF
--- a/lib/swagger-express/index.js
+++ b/lib/swagger-express/index.js
@@ -265,22 +265,7 @@ exports.init = function (app, opt) {
   generate(opt);
 
   // Serve up swagger ui static assets
-  var swHandler = express['static'](opt.swaggerUI);
-
-  // Serve up swagger ui interface.
-  var swaggerURL = new RegExp('^'+ opt.swaggerURL +'(\/.*)?$');
-
-  app.get(swaggerURL, function (req, res, next) {
-    if (req.url === opt.swaggerURL) { // express static barfs on root url w/o trailing slash
-      res.writeHead(302, { 'Location' : req.url + '/' });
-      res.end();
-      return;
-    }
-
-    // take off leading /swagger so that connect locates file correctly
-    req.url = req.url.substr(opt.swaggerURL.length);
-    return swHandler(req, res, next);
-  });
+  app.use(opt.swaggerURL, express.static(opt.swaggerUI));
 
   return function (req, res, next) {
     var match, resource, result;


### PR DESCRIPTION
Admittedly, I haven't delved into the history with the previous implementation,
but passing the mount URL as the first parameter seems to work fine for me.
Perhaps a bug in `express#static` has been fixed since?

This pull request originated from a feature request of being able to serve
Swagger UI from root (`/`), which this handles fine.
