### PR TITLE
Allow models to be specified in separate files

### DIFF
--- a/lib/swagger-express/index.js
+++ b/lib/swagger-express/index.js
@@ -10,6 +10,7 @@ var doctrine = require('doctrine');
 var express = require('express');
 var descriptor = {};
 var resources = {};
+var models = {};
 
 /**
  * Read from yml file
@@ -137,7 +138,10 @@ function readJsDoc(file, fn) {
           descriptor.apis.push(api);
           resource.resourcePath = api.resourcePath;
         } else if (api.models) {
-          resource.models = api.models;
+          modelKeys = _.keys(api.models);
+          if (modelKeys.length > 0) {
+            models[modelKeys[0]] = api.models[modelKeys[0]];
+          }
         } else {
           resource.apis.push(api);
         }
@@ -177,7 +181,10 @@ function readCoffee(file, fn) {
                     descriptor.apis.push(api);
                     resource.resourcePath = api.resourcePath;
                 } else if (api.models) {
-                    resource.models = api.models;
+                    modelKeys = _.keys(api.models);
+                    if (modelKeys.length > 0) {
+                      models[modelKeys[0]] = api.models[modelKeys[0]];
+                    }
                 } else {
                     resource.apis.push(api);
                 }
@@ -305,7 +312,7 @@ exports.init = function (app, opt) {
 
         result.resourcePath = resource.resourcePath;
         result.apis = resource.apis;
-        result.models = resource.models;
+        result.models = models;
       } else {
         result.apis = _.map(result.apis, function (api) {
           return {


### PR DESCRIPTION
I had a use case where I wanted to specify Model docs in files separate from routes/resourcePaths. With this change, you can do something like this:

```
apis: ['./config/routes.js', './app/models/user.js']
```
