### PR TITLE
allow fullSwaggerJSONPath to be set in the cfg.

### DIFF
--- a/lib/swagger-express/index.js
+++ b/lib/swagger-express/index.js
@@ -243,7 +243,10 @@ function generate(opt) {
   opt.swaggerVersion = descriptor.swaggerVersion;
   opt.swaggerURL = descriptor.swaggerURL;
   opt.swaggerJSON = descriptor.swaggerJSON;
-  opt.fullSwaggerJSONPath = url.parse(opt.basePath + opt.swaggerJSON).path;
+
+  if (!opt.fullSwaggerJSONPath) {
+    opt.fullSwaggerJSONPath = url.parse(opt.basePath + opt.swaggerJSON).path;
+  }
 
   if (opt.apis) {
     opt.apis.forEach(function (api) {


### PR DESCRIPTION
In a Layer7 load balancer some of the basePath may be rewritten. As the code keeps assuming the fullSwaggerJSONPath is the concatenation of the basePath and swaggerJSON this will create an invalid url which will never return the docs. This is just a quick fix, but at least solves the problem.
