### PR TITLE
Fix Express 4 warning

### DIFF
--- a/lib/swagger-express/index.js
+++ b/lib/swagger-express/index.js
@@ -296,7 +296,8 @@ exports.init = function (app, opt) {
         resource = resources[match[1]];
 
         if (!resource) {
-          return res.send(404);
+          //detect if it's express 4.x or 3.5.x
+          return (res.sendStatus ? res.sendStatus(404) : res.send(404));
         }
 
         result.resourcePath = resource.resourcePath;


### PR DESCRIPTION
Error:
express deprecated res.send(status): Use res.sendStatus(status) instead node_modules/swagger-express/lib/swagger-express/index.js:299:22

This module is still supporting express 3.5.x, so for the time being, there is some quick check if the sendStatus method is defined