### PR TITLE
replace swagger version field  with

### DIFF
--- a/lib/swagger-express/index.js
+++ b/lib/swagger-express/index.js
@@ -230,7 +230,7 @@ function generate(opt) {
 
   descriptor.basePath = opt.basePath;
   descriptor.apiVersion = (opt.apiVersion) ? opt.apiVersion : '1.0';
-  descriptor.swaggerVersion = (opt.swaggerVersion) ? opt.swaggerVersion : '1.0';
+  descriptor.swaggerVersion = descriptor.swagger = (opt.swaggerVersion) ? opt.swaggerVersion : '1.0';
   descriptor.swaggerURL = (opt.swaggerURL) ? opt.swaggerURL : '/swagger';
   descriptor.swaggerJSON = (opt.swaggerJSON) ? opt.swaggerJSON : '/api-docs.json';
   descriptor.apis = [];


### PR DESCRIPTION
### Abstract 
`swaggerVersion`is not recognized by swagger so replaced `swaggerVersion` with `swagger`.
for backward compatibility, appended this field.

![image](https://cloud.githubusercontent.com/assets/10035/16006937/943d8436-31aa-11e6-90b0-63d6ea92621d.png)
