### PR TITLE
Read APIs in the order specified in swagger.init()

### DIFF
--- a/lib/swagger-express/index.js
+++ b/lib/swagger-express/index.js
@@ -249,12 +249,10 @@ function generate(opt) {
   }
 
   if (opt.apis) {
-    opt.apis.forEach(function (api) {
-      readApi(api, function (err) {
-        if (err) {
-          throw err;
-        }
-      });
+    async.forEachSeries(opt.apis, function(api, cb) {
+      readApi(api, cb);
+    }, function(err) {
+      if(err) throw err;
     });
   }
 }


### PR DESCRIPTION
This PR makes the APIs are read in series. If not, it can happen that the files are finished read in different order that the specified in swagger.init() function. With this change the API order in the UI is always the same.